### PR TITLE
Update Plotly JS version to support newest the Plotly Python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ packages = find:
 include_package_data = True
 install_requires =
     trame-client
+    plotly>=6.0.0
 
 [semantic_release]
 version_pattern = setup.cfg:version = (\d+\.\d+\.\d+)

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "plotly.js-dist-min": "^2.24.3"
+        "plotly.js-dist-min": "^3.0.0"
       },
       "devDependencies": {
         "@rushstack/eslint-patch": "^1.1.4",
@@ -6274,9 +6274,10 @@
       }
     },
     "node_modules/plotly.js-dist-min": {
-      "version": "2.24.3",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.24.3.tgz",
-      "integrity": "sha512-NuX+/VaimP++uPlS4YdPOX/fg0ffOOvoaNmJenNcEu9fFWckCWxKkrknA5Jk7ZeweTEpzYTz6K1VGOstf8/PCw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-3.0.0.tgz",
+      "integrity": "sha512-AlU1XkNRzwUI55A+kJYj0xJETp3h7aeFe4O1cmhzOryscYdw9jOywXZo+7Zy+y2kEKq12CnTzII4jV7Vgpy4xQ==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.4.23",
@@ -12099,9 +12100,9 @@
       }
     },
     "plotly.js-dist-min": {
-      "version": "2.24.3",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.24.3.tgz",
-      "integrity": "sha512-NuX+/VaimP++uPlS4YdPOX/fg0ffOOvoaNmJenNcEu9fFWckCWxKkrknA5Jk7ZeweTEpzYTz6K1VGOstf8/PCw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-3.0.0.tgz",
+      "integrity": "sha512-AlU1XkNRzwUI55A+kJYj0xJETp3h7aeFe4O1cmhzOryscYdw9jOywXZo+7Zy+y2kEKq12CnTzII4jV7Vgpy4xQ=="
     },
     "postcss": {
       "version": "8.4.23",

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -19,7 +19,7 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
-    "plotly.js-dist-min": "^2.24.3"
+    "plotly.js-dist-min": "^3.0.0"
   },
   "peerDependencies": {
     "vue": "^2.7.0 || >=3.0.0"


### PR DESCRIPTION
Closes #6

Warning, I believe this might be a breaking change (with backward-compatibility), I guess it depends on if Plotly 6.0.0 introduced breaking changes...

Either way, probably deserves a increase in the major release to be safe.