### PR TITLE
Update plotly version in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,4 +169,4 @@ Share your experience `with a testimonial <https://github.com/Kitware/trame/issu
 JavaScript dependency
 -----------------------------------------------------------
 
-This Python package bundle the ``plotly.js-dist-min@2.24.3`` JavaScript library. If you would like us to upgrade it, `please reach out <https://www.kitware.com/trame/>`_.
+This Python package bundle the ``plotly.js-dist-min@3.0.0`` JavaScript library. If you would like us to upgrade it, `please reach out <https://www.kitware.com/trame/>`_.


### PR DESCRIPTION
Didn't notice this section in the README.